### PR TITLE
ci: add distFolderPath to publish

### DIFF
--- a/packages/cypress-ct-qwik/project.json
+++ b/packages/cypress-ct-qwik/project.json
@@ -80,7 +80,8 @@
     "publish": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {
-        "access": "public"
+        "access": "public",
+        "distFolderPath": "dist/packages/cypress-ct-qwik"
       }
     },
     "push-to-github": {


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests
- [ ] Other

# Description

It appears that the `cypress-ct-qwik:publish`[ task is failing](https://github.com/qwikifiers/cypress-qwik/actions/runs/4547658494/jobs/8017829089#step:4:47). This PR adds the `distFolderPath` option to the `ngx-deploy-npm:deploy` executor.

# Use cases and why

# Screenshots/Demo


# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/cypress-qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
