### PR TITLE
ref(cypress-ct-qwik): update package.json types

### DIFF
--- a/packages/cypress-ct-qwik/project.json
+++ b/packages/cypress-ct-qwik/project.json
@@ -47,7 +47,7 @@
       "options": {
         "outputPath": "dist/packages/cypress-ct-qwik",
         "commands": [
-          "nx run cypress-ct-qwik:build-mount --skip-nx-cache && nx run cypress-ct-qwik:build-definition --skip-nx-cache"
+          "nx run cypress-ct-qwik:build-definition --skip-nx-cache && nx run cypress-ct-qwik:build-mount --skip-nx-cache"
         ]
       },
       "outputPath": "node_modules/cypress-ct-qwik",

--- a/packages/cypress-ct-qwik/src/index.ts
+++ b/packages/cypress-ct-qwik/src/index.ts
@@ -1,2 +1,1 @@
-export * from './lib/add-qwik-loader';
 export * from './lib/mount';


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [X] Bug
- [ ] Docs / tests
- [ ] Other

# Description

This PR inverses the `cypress-ct-qwik:build-mount` and `cypress-ct-qwik:mount-definition` executors so that the `build-mount` one is executed last and therefore types are exported correctly in the `package.json` file.

# Use cases and why

As it currently stands we are exporting the `definition.d.ts` file so that in the support file when we try to add the `mount` command it can't find the correct type.

# Screenshots/Demo

<img width="280" alt="Screenshot 2023-03-29 at 3 34 38 PM" src="https://user-images.githubusercontent.com/3605268/228648362-86cf4c73-007f-4687-8f9e-f4a00c127692.png">


# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/qwikifiers/cypress-qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
